### PR TITLE
Add utf-8 encoding to print

### DIFF
--- a/pylynk.py
+++ b/pylynk.py
@@ -125,7 +125,7 @@ def download_sbom(lynk_ctx):
         print('Failed to fetch SBOM')
         return 1
 
-    print(sbom)
+    print(sbom.encode("utf-8"))
     return 0
 
 def upload_sbom(lynk_ctx, sbom_file):


### PR DESCRIPTION
To avoid encoding issues on the terminal, we need to encode sbom to utf-8 before printing it. 