### PR TITLE
include vuln while downloading sbom

### DIFF
--- a/lynkctx.py
+++ b/lynkctx.py
@@ -298,7 +298,7 @@ class LynkContext:
         variables = {
             "envId": self.env_id,
             "sbomId": self.ver_id,
-            "includeVulns": False
+            "includeVulns": True
         }
 
         request_data = {

--- a/pylynk.py
+++ b/pylynk.py
@@ -309,6 +309,8 @@ def setup_args():
 
     download_parser.add_argument(
         "--output", help="Output file", required=False)
+    
+    download_parser.add_argument("--vuln", help="Vulnerabilities", required=False)
 
     args = parser.parse_args()
     return args
@@ -349,7 +351,8 @@ def setup_lynk_context(args):
         getattr(args, 'env', None),
         getattr(args, 'verId', None),
         getattr(args, 'ver', None),
-        getattr(args, 'output', None)
+        getattr(args, 'output', None),
+        getattr(args, "vuln", None),
     )
 
 


### PR DESCRIPTION
This PR adds the following changes:
- It includes the vulnerabilities while downloading SBOM.

Proof:
```bash
 ➜  python3  pylynk.py prods --table 
NAME           | ID                                   | VERSIONS | UPDATED AT                    | 
-------------------------------------------------------------------------------------------------|
foldermonitor6 | ab9928c8-f381-446b-9979-180949266333 | 11       | 2025-03-13 00:54:56 UTC+05:30 | 
foldermonitor5 | 70b7332a-e8bd-47a1-bad1-0efa4f99c3b2 | 11       | 2025-03-13 00:54:54 UTC+05:30 | 
foldermonitor3 | 753db482-944a-4310-9252-167ead5b7848 | 11       | 2025-03-13 00:03:11 UTC+05:30 | 
foldermonitor2 | ded0ff58-65f3-48db-babf-5af5d9943f9c | 11       | 2025-03-12 23:01:34 UTC+05:30 | 
foldermonitor1 | 031d698f-ab63-46b9-9b97-71a11c10afbb | 11       | 2025-03-12 22:53:56 UTC+05:30 | 
Demo Product   | 3bf4e076-2a1f-439d-a10e-7f38be7ceb2a | 1        | 2025-03-12 01:07:24 UTC+05:30 | 


➜ python3 pylynk.py vers --prodId  3bf4e076-2a1f-439d-a10e-7f38be7ceb2a  --table
ID                                   | VERSION | PRIMARY COMPONENT | UPDATED AT                    |
---------------------------------------------------------------------------------------------------|
1404e12f-f7c6-4034-be8f-cad7ca5b4258 | v1.0.0  | Demo Application  | 2025-03-12 01:07:24 UTC+05:30 |


➜ python3 pylynk.py download --env default --verId 1404e12f-f7c6-4034-be8f-cad7ca5b4258  --prodId 3bf4e076-2a1f-439d-a10e-7f38be7ceb2a --output=vuln300.json 
```
[vuln300.json](https://github.com/user-attachments/files/19223318/vuln300.json)
