### PR TITLE
ci: fix smoke tests and use uv

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -24,17 +24,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: pip install -r requirements.txt
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Smoke test — prods
         run: |
-          python -m pylynk prods --output=json | python -c "
+          uv run python -m pylynk prods --output=json | python -c "
           import sys, json
           prods = json.load(sys.stdin)
           assert len(prods) > 0, 'Expected at least one product'
@@ -47,7 +42,7 @@ jobs:
         run: |
           # vers prints info messages to stdout when no --ver given,
           # so capture to file and extract the JSON portion
-          python -m pylynk vers \
+          uv run python -m pylynk vers \
             --prod "$TEST_PRODUCT" \
             --env "$TEST_ENV" \
             --output=json > vers_output.txt 2>&1
@@ -66,20 +61,24 @@ jobs:
 
       - name: Smoke test — vers
         run: |
-          python -m pylynk vers \
+          # vers lists all versions (no --ver flag), so capture and extract JSON
+          uv run python -m pylynk vers \
             --prod "$TEST_PRODUCT" \
             --env "$TEST_ENV" \
-            --ver "$TEST_VERSION" \
-            --output=json | python -c "
-          import sys, json
-          vers = json.load(sys.stdin)
+            --output=json > vers_test.txt 2>&1
+          python -c "
+          import json
+          with open('vers_test.txt') as f:
+              lines = f.readlines()
+          json_start = next(i for i, l in enumerate(lines) if l.strip().startswith('['))
+          vers = json.loads(''.join(lines[json_start:]))
           assert len(vers) > 0, 'Expected at least one version'
           print(f'OK: {len(vers)} versions')
           "
 
       - name: Smoke test — status
         run: |
-          python -m pylynk status \
+          uv run python -m pylynk status \
             --prod "$TEST_PRODUCT" \
             --env "$TEST_ENV" \
             --ver "$TEST_VERSION" \
@@ -95,7 +94,7 @@ jobs:
       - name: Smoke test — download
         run: |
           echo "Downloading version: $TEST_VERSION"
-          python -m pylynk download \
+          uv run python -m pylynk download \
             --prod "$TEST_PRODUCT" \
             --env "$TEST_ENV" \
             --ver "$TEST_VERSION" | python -c "
@@ -108,28 +107,36 @@ jobs:
 
       - name: Smoke test — vulns
         run: |
-          python -m pylynk vulns \
+          # vulns may print "No vulnerabilities found" instead of JSON when empty
+          uv run python -m pylynk vulns \
             --prod "$TEST_PRODUCT" \
             --env "$TEST_ENV" \
             --ver "$TEST_VERSION" \
-            --output=json | python -c "
-          import sys, json
-          data = json.load(sys.stdin)
-          # data is either a list of vulns or an empty list
-          print(f'OK: {len(data)} vulnerabilities')
+            --output=json > vulns_output.txt 2>&1
+          python -c "
+          import json
+          with open('vulns_output.txt') as f:
+              text = f.read().strip()
+          if 'No vulnerabilities found' in text:
+              print('OK: 0 vulnerabilities')
+          else:
+              data = json.loads(text)
+              print(f'OK: {len(data)} vulnerabilities')
           "
 
       - name: Smoke test — report attribution
         run: |
-          python -m pylynk report \
+          # Capture to file to avoid BrokenPipeError from piping to head
+          uv run python -m pylynk report \
             --type attribution \
             --prod "$TEST_PRODUCT" \
             --env "$TEST_ENV" \
-            --ver "$TEST_VERSION" | head -1 | python -c "
-          import sys
-          header = sys.stdin.readline().strip()
+            --ver "$TEST_VERSION" > report_output.txt 2>&1
+          python -c "
+          with open('report_output.txt') as f:
+              header = f.readline().strip()
           assert 'Component Name' in header, f'Unexpected header: {header}'
-          print(f'OK: attribution report header valid')
+          print('OK: attribution report header valid')
           "
 
       - name: Notify Slack on failure


### PR DESCRIPTION
## Summary

- Replace `setup-python` + `pip install` with `astral-sh/setup-uv` — all pylynk commands run via `uv run`
- Fix `vers` step: command has no `--ver` flag, capture to file and extract JSON to handle info messages on stdout
- Fix `vulns` step: handle `No vulnerabilities found` text output when there are zero vulns (not valid JSON)
- Fix `report` step: capture to file to avoid `BrokenPipeError` from piping to `head`

All 7 steps verified locally against the live API.

## Test plan

- [ ] CI passes on this PR
- [ ] Trigger workflow manually after merge to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)