### PR TITLE
fix(vex): paginate vuln resolver, fix vulns ID column, list option names

### DIFF
--- a/pylynk/api/client.py
+++ b/pylynk/api/client.py
@@ -775,31 +775,71 @@ class LynkAPIClient:
 
         return self.config.ver_id is not None
 
-    def get_vulnerabilities(self, project_id, sbom_id, limit=1000):
+    def _iter_vulnerability_pages(self, project_id, sbom_id, page_size=100):
+        """Yield each page of vulnerabilities via cursor pagination."""
+        after = None
+        while True:
+            variables = {
+                'projectId': project_id,
+                'sbomId': sbom_id,
+                'first': page_size,
+                'after': after,
+            }
+            result = self._make_request(VULNS_LIST, variables, 'GetVulnProductDetails')
+            if not result or 'data' not in result:
+                return
+            vulns_page = (result['data'].get('sbom') or {}).get('vulns') or {}
+            yield vulns_page
+            page_info = vulns_page.get('pageInfo') or {}
+            if not page_info.get('hasNextPage'):
+                return
+            after = page_info.get('endCursor')
+            if not after:
+                return
+
+    def get_vulnerabilities(self, project_id, sbom_id, limit=None, page_size=100):
         """
-        Get vulnerabilities for a specific SBOM.
+        Get vulnerabilities for a specific SBOM, paginating through all pages.
 
         Args:
             project_id (str): Project/Environment ID
             sbom_id (str): SBOM/Version ID
-            limit (int): Maximum number of results
+            limit (int): Optional cap on returned nodes (None = fetch all)
+            page_size (int): Page size per GraphQL request
 
         Returns:
-            dict: Vulnerability data with nodes and totalCount, or None if error
+            dict: {'nodes': [...], 'totalCount': N}, or None on request failure
         """
-        variables = {
-            'projectId': project_id,
-            'sbomId': sbom_id,
-            'first': limit
-        }
+        all_nodes = []
+        total_count = 0
+        any_page = False
+        for page in self._iter_vulnerability_pages(project_id, sbom_id, page_size):
+            any_page = True
+            total_count = page.get('totalCount', total_count)
+            all_nodes.extend(page.get('nodes', []))
+            if limit and len(all_nodes) >= limit:
+                all_nodes = all_nodes[:limit]
+                break
+        if not any_page:
+            return None
+        return {'nodes': all_nodes, 'totalCount': total_count}
 
-        result = self._make_request(VULNS_LIST, variables, 'GetVulnProductDetails')
+    _VEX_OPTION_QUERIES = {
+        'status': (VEX_STATUSES_LIST, 'vexStatuses', 'GetVexStatuses'),
+        'justification': (VEX_JUSTIFICATIONS_LIST, 'vexJustifications', 'GetVexJustifications'),
+        'response': (CDX_RESPONSES_LIST, 'cdxResponses', 'GetCdxResponses'),
+    }
 
-        if result and 'data' in result:
-            sbom_data = result['data'].get('sbom', {})
-            return sbom_data.get('vulns', {})
-
-        return None
+    def _fetch_vex_option_nodes(self, option_type):
+        """Return the raw list of option nodes for a VEX option type."""
+        if option_type not in self._VEX_OPTION_QUERIES:
+            return []
+        query, root_key, operation_name = self._VEX_OPTION_QUERIES[option_type]
+        result = self._make_request(query, operation_name=operation_name)
+        if not result or result.get('errors'):
+            return []
+        option_data = result.get('data', {}).get(root_key, [])
+        return option_data.get('nodes', []) if isinstance(option_data, dict) else option_data
 
     def resolve_vex_option_id(self, option_type, name):
         """
@@ -812,24 +852,9 @@ class LynkAPIClient:
         Returns:
             str: Matching option ID, or None if not found
         """
-        query_map = {
-            'status': (VEX_STATUSES_LIST, 'vexStatuses', 'GetVexStatuses'),
-            'justification': (VEX_JUSTIFICATIONS_LIST, 'vexJustifications', 'GetVexJustifications'),
-            'response': (CDX_RESPONSES_LIST, 'cdxResponses', 'GetCdxResponses'),
-        }
-        if option_type not in query_map or not name:
+        if not name:
             return None
-
-        query, root_key, operation_name = query_map[option_type]
-        result = self._make_request(
-            query,
-            operation_name=operation_name
-        )
-        if not result or result.get('errors'):
-            return None
-
-        option_data = result.get('data', {}).get(root_key, [])
-        nodes = option_data.get('nodes', []) if isinstance(option_data, dict) else option_data
+        nodes = self._fetch_vex_option_nodes(option_type)
         normalized_name = self._normalize_lookup_name(name)
         matched = next(
             (node for node in nodes
@@ -837,6 +862,14 @@ class LynkAPIClient:
             None
         )
         return matched.get('id') if matched else None
+
+    def list_vex_option_names(self, option_type):
+        """Return all known names for a VEX option type."""
+        return [
+            node.get('name')
+            for node in self._fetch_vex_option_nodes(option_type)
+            if node.get('name')
+        ]
 
     def resolve_component_vuln_id(self, project_id, sbom_id, vuln_id,
                                   component_name=None, component_version=None):
@@ -853,31 +886,34 @@ class LynkAPIClient:
         Returns:
             str: Component vulnerability ID, or None if not uniquely resolved
         """
-        vulns = self.get_vulnerabilities(project_id, sbom_id)
-        nodes = vulns.get('nodes', []) if vulns else []
         normalized_vuln = self._normalize_lookup_name(vuln_id)
         normalized_component = self._normalize_lookup_name(component_name)
         normalized_version = self._normalize_lookup_name(component_version)
 
         matches = []
-        for node in nodes:
-            vuln = node.get('vuln') or {}
-            aliases = [vuln.get('nvdAliasId'), vuln.get('vulnId'), vuln.get('id')]
-            normalized_aliases = [
-                self._normalize_lookup_name(alias)
-                for alias in aliases
-                if alias
-            ]
-            if normalized_vuln not in normalized_aliases:
-                continue
+        for page in self._iter_vulnerability_pages(project_id, sbom_id):
+            for node in page.get('nodes', []):
+                vuln = node.get('vuln') or {}
+                aliases = [vuln.get('nvdAliasId'), vuln.get('vulnId'), vuln.get('id')]
+                normalized_aliases = [
+                    self._normalize_lookup_name(alias)
+                    for alias in aliases
+                    if alias
+                ]
+                if normalized_vuln not in normalized_aliases:
+                    continue
 
-            component = node.get('component') or {}
-            if normalized_component and self._normalize_lookup_name(component.get('name')) != normalized_component:
-                continue
-            if normalized_version and self._normalize_lookup_name(component.get('version')) != normalized_version:
-                continue
+                component = node.get('component') or {}
+                if normalized_component and self._normalize_lookup_name(component.get('name')) != normalized_component:
+                    continue
+                if normalized_version and self._normalize_lookup_name(component.get('version')) != normalized_version:
+                    continue
 
-            matches.append(node)
+                matches.append(node)
+                if len(matches) > 1:
+                    break
+            if len(matches) > 1:
+                break
 
         if len(matches) == 1:
             return matches[0].get('id')

--- a/pylynk/api/queries.py
+++ b/pylynk/api/queries.py
@@ -365,10 +365,14 @@ query GetAttributionsData($sbomId: Uuid!, $internal: Boolean, $primary: Boolean,
 
 # Query to get vulnerabilities for a specific SBOM
 VULNS_LIST = """
-query GetVulnProductDetails($projectId: Uuid!, $sbomId: Uuid!, $first: Int) {
+query GetVulnProductDetails($projectId: Uuid!, $sbomId: Uuid!, $first: Int, $after: String) {
   sbom(projectId: $projectId, sbomId: $sbomId) {
-    vulns(sbomId: $sbomId, first: $first) {
+    vulns(sbomId: $sbomId, first: $first, after: $after) {
       totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
       nodes {
         id
         isPart

--- a/pylynk/cli/commands/vex.py
+++ b/pylynk/cli/commands/vex.py
@@ -302,7 +302,11 @@ def _resolve_option(api_client, config, row, option_type, row_prefix):
 
     resolved_id = api_client.resolve_vex_option_id(option_type, option_name)
     if not resolved_id:
-        print(f"Error: Could not resolve VEX {option_type} name '{option_name}'. Use --{option_type}-id instead.")
+        valid_names = api_client.list_vex_option_names(option_type)
+        print(f"Error: Could not resolve VEX {option_type} name '{option_name}'.")
+        if valid_names:
+            print(f"Valid {option_type} names: {', '.join(valid_names)}")
+        print(f"Or pass --{option_type}-id directly.")
         return UNRESOLVED_OPTION
     return resolved_id
 

--- a/pylynk/cli/commands/vulns.py
+++ b/pylynk/cli/commands/vulns.py
@@ -141,8 +141,8 @@ def _get_value(vuln, column):
             value = None
             break
 
-    # Try fallback path if primary is None
-    if value is None and 'fallback' in col_def:
+    # Try fallback path if primary is missing or empty
+    if not value and 'fallback' in col_def:
         value = vuln
         for key in col_def['fallback']:
             if isinstance(value, dict):


### PR DESCRIPTION
## Summary

Three related fixes uncovered while running `pylynk vex update` against a CIP-kernel SBOM with 3957 vulnerabilities.

### 1. Paginate the vuln resolver (the actual bug)

`vex update --vuln CVE-XXXX --component NAME --component-version VER` failed for any vulnerability past the first ~100 rows. The server silently caps each `VULNS_LIST` page at 100 even when the client requests 1000, but `get_vulnerabilities` and `resolve_component_vuln_id` only fetched one page — so most of the SBOM was invisible.

- `queries.py`: `VULNS_LIST` now takes `$after: String` and returns `pageInfo { hasNextPage endCursor }`.
- `client.py`: new `_iter_vulnerability_pages` generator. `get_vulnerabilities` walks all pages (with optional `limit`/`page_size`). `resolve_component_vuln_id` scans pages and breaks early once a second match is seen, so unambiguous lookups finish quickly.

### 2. `vulns` ID column was always blank

The `id` column is defined as `vuln.nvdAliasId` with a fallback to `vuln.vulnId` (`constants.py:104`). The server returns `nvdAliasId: ""` for these records, but `_get_value` in `cli/commands/vulns.py` only triggered the fallback on `None`, so the empty string took precedence and the column displayed blank for every row.

- One-line fix: `if value is None and 'fallback' in col_def` → `if not value and 'fallback' in col_def`.

### 3. Unhelpful VEX option errors

When `--status`/`--justification`/`--response` didn't match a known name, the error said "use `--XXX-id` instead" without telling you what the valid names were. Now it lists them.

- `client.py`: factored `_fetch_vex_option_nodes`, added `list_vex_option_names`.
- `vex.py`: `_resolve_option` prints the valid names returned by the API on failure.

## Test plan

Verified against a local stack with a 3957-vuln SBOM:

- [x] `vex update --vuln CVE-2017-17449 --component linux --component-version cip-4.4.302-cip109 --status affected` — previously failed with "Could not find a matching component vulnerability"; now resolves correctly.
- [x] `vulns --columns 'id'` — column now populated with CVE IDs.
- [x] `vulns` returns the full 3957 rows (was 100).
- [x] `vex bulk-update --component-vuln-id <id> --component-vuln-id <id> ...` (mixed early/late page IDs) — succeeds.
- [x] `vex bulk-update --file vex.csv` with `vuln,component,component_version,status` rows where the CVE is on a late page — succeeds.
- [x] `vex bulk-update --file vex.json` with mixed statuses — `_group_bulk_rows` splits into separate mutation batches correctly.
- [x] Bogus `--justification` now prints `Valid justification names: Code not reachable, Code not present, ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)