### PR TITLE
feat(gate): add policy gate command for CI/PR blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,12 @@ python3 pylynk.py download --prod 'my-product' --verId 'version-id' --out-file s
 
 ```bash
 python3 pylynk.py gate --prod 'my-product' --env 'default' --ver 'v1.0.0'
+python3 pylynk.py gate --prod 'my-product' --env 'default' --ver 'v1.0.0' --policy-name 'No criticals'
 # exit 0 = pass, 3 = policy failure, 4 = indeterminate (see docs/gate.md)
 ```
+
+`gate` waits for the asynchronous policy scan and can evaluate either all
+active policies or one active policy with `--policy-name` / `--policy-id`.
 
 ### List Vulnerabilities
 
@@ -220,5 +224,3 @@ docker run --network="host" -e INTERLYNK_SECURITY_TOKEN=$INTERLYNK_SECURITY_TOKE
 If you like this project, please support us by starring it.
 
 [![Stargazers](https://starchart.cc/interlynk-io/pylynk.svg)](https://starchart.cc/interlynk-io/pylynk)
-
-

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ python3 pylynk.py upload --prod 'my-product' --sbom my-sbom.json
 python3 pylynk.py download --prod 'my-product' --verId 'version-id' --out-file sbom.json
 ```
 
+### Enforce Policies in CI (PR Blocking)
+
+```bash
+python3 pylynk.py gate --prod 'my-product' --env 'default' --ver 'v1.0.0'
+# exit 0 = pass, 3 = policy failure, 4 = indeterminate (see docs/gate.md)
+```
+
 ### List Vulnerabilities
 
 ```bash
@@ -112,6 +119,7 @@ docker run -e INTERLYNK_SECURITY_TOKEN=$INTERLYNK_SECURITY_TOKEN \
 | `status` | Check SBOM processing status | [docs/status.md](docs/status.md) |
 | `upload` | Upload an SBOM | [docs/upload.md](docs/upload.md) |
 | `download` | Download an SBOM | [docs/download.md](docs/download.md) |
+| `gate` | Policy gate for CI/PR blocking | [docs/gate.md](docs/gate.md) |
 | `vulns` | List vulnerabilities | [docs/vulns.md](docs/vulns.md) |
 | `vex` | Update VEX data | [docs/vex.md](docs/vex.md) |
 | `report` | Generate reports (e.g., attribution) | [docs/report.md](docs/report.md) |

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -240,3 +240,17 @@ SBOM violates your organization's policies:
 The command waits for the policy scan to finish and exits `3` on policy
 failure or `4` if the scan could not complete (fail closed). See
 [docs/gate.md](gate.md) for exit codes and options.
+
+Use the same version value for upload and gate. In CI, a commit SHA is a good
+choice when your SBOM generator writes it as the primary component version.
+
+To block on only one policy, add `--policy-name`:
+
+```yaml
+      - name: Policy gate for one policy
+        env:
+          INTERLYNK_SECURITY_TOKEN: ${{ secrets.INTERLYNK_TOKEN }}
+        run: |
+          python3 pylynk.py gate --prod 'my-product' --env 'default' \
+            --ver "${{ github.sha }}" --policy-name 'No criticals' --timeout 600
+```

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -222,3 +222,21 @@ The extracted CI information is sent as HTTP headers with upload API requests:
 | `X-Repository-URL` | Repository URL | `https://github.com/org/repo` |
 
 **Note:** These headers are only sent during `upload` operations when CI metadata collection is enabled.
+
+## Blocking Pull Requests on Policy Failures
+
+After uploading, use the `gate` command to make the pipeline fail when the
+SBOM violates your organization's policies:
+
+```yaml
+      - name: Policy gate (blocks PR on failure)
+        env:
+          INTERLYNK_SECURITY_TOKEN: ${{ secrets.INTERLYNK_TOKEN }}
+        run: |
+          python3 pylynk.py gate --prod 'my-product' --env 'default' \
+            --ver "${{ github.sha }}" --timeout 600
+```
+
+The command waits for the policy scan to finish and exits `3` on policy
+failure or `4` if the scan could not complete (fail closed). See
+[docs/gate.md](gate.md) for exit codes and options.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -237,20 +237,12 @@ SBOM violates your organization's policies:
             --ver "${{ github.sha }}" --timeout 600
 ```
 
-The command waits for the policy scan to finish and exits `3` on policy
-failure or `4` if the scan could not complete (fail closed). See
-[docs/gate.md](gate.md) for exit codes and options.
+The command waits for the policy scan to finish and exits non-zero when the
+SBOM does not pass. See [docs/gate.md](gate.md) for the full status and exit
+code table.
 
 Use the same version value for upload and gate. In CI, a commit SHA is a good
 choice when your SBOM generator writes it as the primary component version.
 
-To block on only one policy, add `--policy-name`:
-
-```yaml
-      - name: Policy gate for one policy
-        env:
-          INTERLYNK_SECURITY_TOKEN: ${{ secrets.INTERLYNK_TOKEN }}
-        run: |
-          python3 pylynk.py gate --prod 'my-product' --env 'default' \
-            --ver "${{ github.sha }}" --policy-name 'No criticals' --timeout 600
-```
+To block on only one policy, add `--policy-name 'No criticals'` (or
+`--policy-id`) to the same step.

--- a/docs/gate.md
+++ b/docs/gate.md
@@ -15,6 +15,10 @@ An explicit version is required (either `--ver` or `--verId`). The
 latest-version fallback used by other commands is disabled here because it is
 racy when parallel CI runs upload versions concurrently.
 
+Run `gate` after `upload`. The command waits for asynchronous version creation
+and policy evaluation, prints the final verdict, and returns an exit code that
+CI can use to pass or fail the job.
+
 ## Options
 
 | Option | Description |
@@ -24,6 +28,8 @@ racy when parallel CI runs upload versions concurrently.
 | `--ver` | Version name (mutually exclusive with `--verId`) |
 | `--verId` | Version ID (mutually exclusive with `--ver`) |
 | `--fail-on` | Lowest policy severity that blocks: `fail` (default) or `warn` |
+| `--policy-name` | Gate on one active policy by exact name (mutually exclusive with `--policy-id`) |
+| `--policy-id` | Gate on one active policy by ID (mutually exclusive with `--policy-name`) |
 | `--no-wait` | Check the current state once instead of waiting for the policy scan |
 | `--timeout` | Total seconds to wait for version resolution and policy scan (default: 600) |
 | `--poll-interval` | Seconds between polling attempts (default: 15) |
@@ -59,6 +65,13 @@ Only policies with severity `fail` block by default. Use `--fail-on warn` to
 also block on `warn`-severity policies. Violations of non-blocking severities
 are still listed in the output.
 
+Use `--policy-name` or `--policy-id` to gate on a single active policy instead
+of all active policies. Policy names are matched case-insensitively, and the
+command fails if the name is missing or ambiguous.
+
+When a single policy is selected, the `Policies evaluated` count and the
+violating policy table only include that policy.
+
 ## How Waiting Works
 
 Policy evaluation runs asynchronously after upload (it is chained after the
@@ -88,8 +101,82 @@ python3 pylynk.py gate --prod 'my-product' --env 'default' --ver 'v1.2.3'
 # Block on warnings too, with a longer budget for large SBOMs
 python3 pylynk.py gate --prod 'my-product' --ver 'v1.2.3' --fail-on warn --timeout 900
 
+# Gate on one policy by name
+python3 pylynk.py gate --prod 'my-product' --env 'default' --ver 'v1.2.3' --policy-name 'No criticals'
+
 # One-shot check of an existing version, machine-readable
 python3 pylynk.py gate --verId 'abc-123' --no-wait --output json
+```
+
+## Example Output
+
+Passing gate:
+
+```text
+Policy gate: PASS
+  Policies evaluated: 3 (passed: 2, failed: 0, warned: 1, skipped: 0, errored: 0)
+```
+
+Failing gate:
+
+```text
+Policy gate: FAIL
+  Policies evaluated: 2 (passed: 1, failed: 1, warned: 0, skipped: 0, errored: 0)
+
+POLICY       | SEVERITY | VIOLATIONS
+-------------|----------|-----------
+No criticals | fail     | 4
+```
+
+Single-policy gate:
+
+```bash
+python3 pylynk.py gate \
+  --prod fails \
+  --env default \
+  --ver 4.0.0 \
+  --timeout 600 \
+  --policy-name 'Highly_Exploitable_EPSS_Vulnerability'
+```
+
+```text
+Policy scan in progress (run: NOT_STARTED), retrying in 15s... [599s left]
+Policy gate: FAIL
+  Policies evaluated: 1 (passed: 0, failed: 1, warned: 0, skipped: 0, errored: 0)
+
+POLICY                                | SEVERITY | VIOLATIONS
+--------------------------------------|----------|-----------
+Highly_Exploitable_EPSS_Vulnerability | fail     | 1
+```
+
+JSON output:
+
+```bash
+python3 pylynk.py gate --prod 'my-product' --env 'default' --ver 'v1.2.3' --output json
+```
+
+```json
+{
+  "status": "FAIL",
+  "policyRunStatus": "FINISHED",
+  "evaluatedAt": "2026-08-18T22:31:00Z",
+  "counts": {
+    "total": 1,
+    "failed": 1,
+    "warned": 0,
+    "passed": 0,
+    "errored": 0,
+    "skipped": 0
+  },
+  "violatingPolicies": [
+    {
+      "policyId": "00000000-0000-0000-0000-000000000000",
+      "policyName": "No criticals",
+      "resultType": "fail",
+      "violationsCount": 4
+    }
+  ]
+}
 ```
 
 ## GitHub Actions Example
@@ -132,6 +219,9 @@ export INTERLYNK_SECURITY_TOKEN=your_test_token
 python3 pylynk.py upload --prod test --env default --sbom sample.json
 python3 pylynk.py gate --prod test --env default --ver <version>; echo "exit: $?"
 # expect: exit 3 with the failing policy listed
+
+# Gate on only one active policy
+python3 pylynk.py gate --prod test --env default --ver <version> --policy-name 'No criticals'
 
 # Race check: stop the backend's sidekiq worker, re-upload, then
 python3 pylynk.py gate --prod test --env default --ver <version> --timeout 30; echo "exit: $?"

--- a/docs/gate.md
+++ b/docs/gate.md
@@ -37,29 +37,27 @@ CI can use to pass or fail the job.
 | `--token` | Security token (can also use `INTERLYNK_SECURITY_TOKEN` env var) |
 | `-v, --verbose` | Enable verbose/debug output |
 
-## Exit Codes
+## Statuses and Exit Codes
 
-| Code | Meaning |
-|------|---------|
-| `0` | Gate passed. Also returned when the organization has no active policies (a warning is printed). |
-| `1` | Operational error: authentication, network, or product/version resolution failure. |
-| `2` | Invalid command-line arguments. |
-| `3` | **Policy gate failed** — at least one blocking policy detected violations. |
-| `4` | Indeterminate: the scan timed out, ended in an error, or was never evaluated. The gate fails closed — an incomplete scan never passes. |
-
-Treat any non-zero exit as blocking in CI. Codes `3` and `4` are separate so
-you can alert differently on real policy failures vs. scan problems.
-
-## Gate Statuses
-
-| Status | Exit code | Description |
-|--------|-----------|-------------|
+| Status | Exit | Meaning |
+|--------|------|---------|
 | `PASS` | 0 | All active policies evaluated; no blocking violations |
+| `NO_POLICIES` | 0 | No active policies configured for the organization (a warning is printed) |
 | `FAIL` | 3 | At least one active policy of blocking severity was violated |
-| `NO_POLICIES` | 0 | No active policies configured for the organization |
-| `IN_PROGRESS` | 4 (after timeout) | Policy scan is queued or running |
-| `ERROR` | 4 | Evaluation incomplete or errored (e.g., an interrupted scan) |
-| `NOT_EVALUATED` | 4 | No policy scan applies (e.g., vulnerability scanning disabled for the environment) |
+| `IN_PROGRESS` | 4 | Scan still queued or running when the timeout was reached |
+| `ERROR` | 4 | Evaluation incomplete or errored, such as an interrupted scan |
+| `NOT_EVALUATED` | 4 | No policy scan applies, such as vulnerability scanning disabled for the environment |
+
+Two exits carry no status, because the gate never got a verdict:
+
+| Exit | Meaning |
+|------|---------|
+| `1` | Authentication, network, or resolution failure, including a missing `--verId` or `--prod --ver` combination |
+| `2` | Arguments rejected by the parser |
+
+Treat any non-zero exit as blocking in CI. `3` and `4` are separate so you can
+alert differently on a real policy failure than on a scan that never completed.
+Exit `4` is the fail-closed case: an incomplete scan never passes.
 
 Only policies with severity `fail` block by default. Use `--fail-on warn` to
 also block on `warn`-severity policies. Violations of non-blocking severities

--- a/docs/gate.md
+++ b/docs/gate.md
@@ -1,0 +1,139 @@
+# Gate Command (`gate`)
+
+Check whether an SBOM version passes your organization's policies, and exit
+non-zero when it does not. Designed for CI pipelines: run it after `upload`
+and the exit code blocks the pull request.
+
+## Usage
+
+```bash
+python3 pylynk.py gate --prod <product-name> --env <environment> --ver <version> [OPTIONS]
+python3 pylynk.py gate --verId <version-id> [OPTIONS]
+```
+
+An explicit version is required (either `--ver` or `--verId`). The
+latest-version fallback used by other commands is disabled here because it is
+racy when parallel CI runs upload versions concurrently.
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--prod` | Product name |
+| `--env` | Environment name (optional, defaults to 'default') |
+| `--ver` | Version name (mutually exclusive with `--verId`) |
+| `--verId` | Version ID (mutually exclusive with `--ver`) |
+| `--fail-on` | Lowest policy severity that blocks: `fail` (default) or `warn` |
+| `--no-wait` | Check the current state once instead of waiting for the policy scan |
+| `--timeout` | Total seconds to wait for version resolution and policy scan (default: 600) |
+| `--poll-interval` | Seconds between polling attempts (default: 15) |
+| `--output` | Output format: `table` (default) or `json` |
+| `--token` | Security token (can also use `INTERLYNK_SECURITY_TOKEN` env var) |
+| `-v, --verbose` | Enable verbose/debug output |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Gate passed. Also returned when the organization has no active policies (a warning is printed). |
+| `1` | Operational error: authentication, network, or product/version resolution failure. |
+| `2` | Invalid command-line arguments. |
+| `3` | **Policy gate failed** — at least one blocking policy detected violations. |
+| `4` | Indeterminate: the scan timed out, ended in an error, or was never evaluated. The gate fails closed — an incomplete scan never passes. |
+
+Treat any non-zero exit as blocking in CI. Codes `3` and `4` are separate so
+you can alert differently on real policy failures vs. scan problems.
+
+## Gate Statuses
+
+| Status | Exit code | Description |
+|--------|-----------|-------------|
+| `PASS` | 0 | All active policies evaluated; no blocking violations |
+| `FAIL` | 3 | At least one active policy of blocking severity was violated |
+| `NO_POLICIES` | 0 | No active policies configured for the organization |
+| `IN_PROGRESS` | 4 (after timeout) | Policy scan is queued or running |
+| `ERROR` | 4 | Evaluation incomplete or errored (e.g., an interrupted scan) |
+| `NOT_EVALUATED` | 4 | No policy scan applies (e.g., vulnerability scanning disabled for the environment) |
+
+Only policies with severity `fail` block by default. Use `--fail-on warn` to
+also block on `warn`-severity policies. Violations of non-blocking severities
+are still listed in the output.
+
+## How Waiting Works
+
+Policy evaluation runs asynchronously after upload (it is chained after the
+vulnerability scan), so `gate` waits by default:
+
+1. If `--prod/--ver` names are given, it retries resolution until the
+   uploaded version appears.
+2. It then polls the policy verdict until the scan finishes or `--timeout`
+   is reached.
+
+Both phases share the single `--timeout` budget. On timeout the gate exits
+`4` (fail closed).
+
+## Requirements
+
+- The security token's organization role must grant the `view_policies`
+  permission (all built-in roles include it).
+- `--ver` must match the primary component version embedded in the uploaded
+  SBOM (the same value shown by `pylynk vers`).
+
+## Examples
+
+```bash
+# Gate on the version uploaded by this CI run
+python3 pylynk.py gate --prod 'my-product' --env 'default' --ver 'v1.2.3'
+
+# Block on warnings too, with a longer budget for large SBOMs
+python3 pylynk.py gate --prod 'my-product' --ver 'v1.2.3' --fail-on warn --timeout 900
+
+# One-shot check of an existing version, machine-readable
+python3 pylynk.py gate --verId 'abc-123' --no-wait --output json
+```
+
+## GitHub Actions Example
+
+```yaml
+jobs:
+  sbom-policy-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Generate SBOM
+        run: |
+          # Your SBOM generation command here
+
+      - name: Upload SBOM to Interlynk
+        env:
+          INTERLYNK_SECURITY_TOKEN: ${{ secrets.INTERLYNK_TOKEN }}
+        run: |
+          python3 pylynk.py upload --prod 'my-product' --env 'default' --sbom sbom.json
+
+      - name: Policy gate (blocks PR on failure)
+        env:
+          INTERLYNK_SECURITY_TOKEN: ${{ secrets.INTERLYNK_TOKEN }}
+        run: |
+          python3 pylynk.py gate --prod 'my-product' --env 'default' \
+            --ver "${{ github.sha }}" --timeout 600
+```
+
+The upload step automatically attaches PR metadata (PR number, commit SHA,
+repository) from the CI environment; see [docs/ci-cd.md](ci-cd.md).
+
+## Testing Locally
+
+```bash
+export INTERLYNK_API_URL=http://localhost:3000/lynkapi
+export INTERLYNK_SECURITY_TOKEN=your_test_token
+
+# Create a fail-severity policy in the UI that your SBOM violates, then:
+python3 pylynk.py upload --prod test --env default --sbom sample.json
+python3 pylynk.py gate --prod test --env default --ver <version>; echo "exit: $?"
+# expect: exit 3 with the failing policy listed
+
+# Race check: stop the backend's sidekiq worker, re-upload, then
+python3 pylynk.py gate --prod test --env default --ver <version> --timeout 30; echo "exit: $?"
+# expect: exit 4 (fail closed - never a false pass while the scan is queued)
+```

--- a/pylynk/__main__.py
+++ b/pylynk/__main__.py
@@ -23,7 +23,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from pylynk.cli.parser import create_parser
 from pylynk.utils.config import Config
 from pylynk.api.client import LynkAPIClient
-from pylynk.cli.commands import products, versions, status, upload, download, version, vulns, report, vex
+from pylynk.cli.commands import products, versions, status, upload, download, version, vulns, report, vex, gate
 
 
 def main():
@@ -71,9 +71,30 @@ def main():
             print("For more information: pylynk download --help")
             return 1
     
+    # Validate gate parameters early: require an explicit version - the
+    # latest-version fallback is racy when parallel CI runs upload versions
+    if args.subcommand == "gate":
+        has_id_params = bool(config.ver_id)
+        has_name_params = bool(config.prod and config.ver)
+
+        if not has_id_params and not has_name_params:
+            print("Error: Missing required parameters for gate")
+            print()
+            print("Please provide either:")
+            print("  --verId <version-id>")
+            print("    OR")
+            print("  --prod <product> --ver <version> [--env <environment>]")
+            print()
+            print("Examples:")
+            print("  pylynk gate --verId 'abc-123-def'")
+            print("  pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0'")
+            print()
+            print("For more information: pylynk gate --help")
+            return 1
+
     # Execute the appropriate command
     exit_code = 0
-    
+
     if args.subcommand == "prods":
         exit_code = products.execute(api_client, config)
     elif args.subcommand == "vers":
@@ -84,6 +105,8 @@ def main():
         exit_code = upload.execute(api_client, config, args.sbom)
     elif args.subcommand == "download":
         exit_code = download.execute(api_client, config)
+    elif args.subcommand == "gate":
+        exit_code = gate.execute(api_client, config)
     elif args.subcommand == "vulns":
         exit_code = vulns.execute(api_client, config)
     elif args.subcommand == "vex":
@@ -99,6 +122,7 @@ def main():
         print("  status     Check SBOM processing status")
         print("  upload     Upload an SBOM")
         print("  download   Download an SBOM")
+        print("  gate       Check the policy gate for an SBOM (CI/PR blocking)")
         print("  vulns      List vulnerabilities")
         print("  vex        Update VEX data")
         print("  report     Generate reports")

--- a/pylynk/__main__.py
+++ b/pylynk/__main__.py
@@ -26,6 +26,44 @@ from pylynk.api.client import LynkAPIClient
 from pylynk.cli.commands import products, versions, status, upload, download, version, vulns, report, vex, gate
 
 
+# Commands that address a version by --verId or by name, and the name
+# combination each one accepts. gate requires an explicit --ver because the
+# latest-version fallback is racy when parallel CI runs upload versions.
+VERSION_TARGET_COMMANDS = {
+    "download": {
+        "names": "--prod <product> --env <environment> --ver <version>",
+        "example": "pylynk download --prod 'my-product' --env 'default' --ver 'v1.0.0'",
+        "resolved": lambda c: all([c.prod, c.env, c.ver]),
+    },
+    "gate": {
+        "names": "--prod <product> --ver <version> [--env <environment>]",
+        "example": "pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0'",
+        "resolved": lambda c: bool(c.prod and c.ver),
+    },
+}
+
+
+def _require_version_target(subcommand, config):
+    """Print usage and return False when the version target is incomplete."""
+    spec = VERSION_TARGET_COMMANDS.get(subcommand)
+    if spec is None or config.ver_id or spec["resolved"](config):
+        return True
+
+    print(f"Error: Missing required parameters for {subcommand}")
+    print()
+    print("Please provide either:")
+    print("  --verId <version-id>")
+    print("    OR")
+    print(f"  {spec['names']}")
+    print()
+    print("Examples:")
+    print(f"  pylynk {subcommand} --verId 'abc-123-def'")
+    print(f"  {spec['example']}")
+    print()
+    print(f"For more information: pylynk {subcommand} --help")
+    return False
+
+
 def main():
     """Main function that serves as the entry point of the program."""
     # Parse command line arguments
@@ -51,46 +89,8 @@ def main():
     if not api_client.initialize_minimal():
         return 1
 
-    # Validate download parameters early
-    if args.subcommand == "download":
-        has_id_params = bool(config.ver_id)
-        has_name_params = all([config.prod, config.env, config.ver])
-
-        if not has_id_params and not has_name_params:
-            print("Error: Missing required parameters for download")
-            print()
-            print("Please provide either:")
-            print("  --verId <version-id>")
-            print("    OR")
-            print("  --prod <product> --env <environment> --ver <version>")
-            print()
-            print("Examples:")
-            print("  pylynk download --verId 'abc-123-def'")
-            print("  pylynk download --prod 'my-product' --env 'default' --ver 'v1.0.0'")
-            print()
-            print("For more information: pylynk download --help")
-            return 1
-    
-    # Validate gate parameters early: require an explicit version - the
-    # latest-version fallback is racy when parallel CI runs upload versions
-    if args.subcommand == "gate":
-        has_id_params = bool(config.ver_id)
-        has_name_params = bool(config.prod and config.ver)
-
-        if not has_id_params and not has_name_params:
-            print("Error: Missing required parameters for gate")
-            print()
-            print("Please provide either:")
-            print("  --verId <version-id>")
-            print("    OR")
-            print("  --prod <product> --ver <version> [--env <environment>]")
-            print()
-            print("Examples:")
-            print("  pylynk gate --verId 'abc-123-def'")
-            print("  pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0'")
-            print()
-            print("For more information: pylynk gate --help")
-            return 1
+    if not _require_version_target(args.subcommand, config):
+        return 1
 
     # Execute the appropriate command
     exit_code = 0

--- a/pylynk/api/client.py
+++ b/pylynk/api/client.py
@@ -24,7 +24,7 @@ from pylynk.constants import (
     API_TIMEOUT, DEFAULT_ENVIRONMENT,
     STATUS_NOT_STARTED, STATUS_IN_PROGRESS, STATUS_FINISHED,
     STATUS_COMPLETED, STATUS_UNKNOWN, STATUS_KEYS,
-    GATE_STATUS_IN_PROGRESS, GATE_STATUS_ERROR
+    GATE_STATUS_IN_PROGRESS, GATE_STATUS_ERROR, DEFAULT_GATE_POLL_INTERVAL
 )
 from pylynk.utils.validators import validate_file_exists, validate_boolean_flag, parse_boolean_flag
 from pylynk.api.queries import PRODUCTS_TOTAL_COUNT, PRODUCTS_LIST, PRODUCTS_LIST_LITE, SBOM_DOWNLOAD, SBOM_DOWNLOAD_NEW, VULNS_LIST, ATTRIBUTIONS_QUERY, ATTRIBUTIONS_WITH_TEXT_QUERY, PRODUCT_BY_NAME, VEX_STATUSES_LIST, VEX_JUSTIFICATIONS_LIST, CDX_RESPONSES_LIST, SBOM_POLICY_GATE
@@ -1090,7 +1090,8 @@ class LynkAPIClient:
         return True
 
     def resolve_version_with_retry(self, prod_name, env_name, ver_name,
-                                   deadline, poll_interval=15):
+                                   deadline=None,
+                                   poll_interval=DEFAULT_GATE_POLL_INTERVAL):
         """
         Resolve product/environment/version, retrying until the version appears.
 
@@ -1103,6 +1104,7 @@ class LynkAPIClient:
             env_name (str): Environment name
             ver_name (str): Version name (required - no latest-version fallback)
             deadline (float): time.time() timestamp to give up at
+                              (None = single attempt)
             poll_interval (int): Seconds between attempts
 
         Returns:
@@ -1114,7 +1116,7 @@ class LynkAPIClient:
             if self.resolve_product_env(prod_name, env_name, ver_name):
                 return True
 
-            remaining = deadline - time.time()
+            remaining = (deadline - time.time()) if deadline else 0
             if remaining <= 0:
                 return False
 
@@ -1164,8 +1166,8 @@ class LynkAPIClient:
         return gate
 
     def wait_for_policy_gate(self, sbom_id, fail_on='fail', deadline=None,
-                             poll_interval=15, policy_id=None,
-                             policy_name=None):
+                             poll_interval=DEFAULT_GATE_POLL_INTERVAL,
+                             policy_id=None, policy_name=None):
         """
         Poll the policy gate until it reaches a terminal status or the deadline.
 

--- a/pylynk/api/client.py
+++ b/pylynk/api/client.py
@@ -1168,7 +1168,8 @@ class LynkAPIClient:
             SBOM_POLICY_GATE,
             variables={
                 'sbomId': sbom_id,
-                'failOn': fail_on,
+                # failOn is a GraphQL enum: FAIL / WARN
+                'failOn': fail_on.upper(),
                 'policyId': policy_id,
                 'policyName': policy_name,
             },

--- a/pylynk/api/client.py
+++ b/pylynk/api/client.py
@@ -45,6 +45,9 @@ class LynkAPIClient:
         self._data = None
         self._products_count = None
         self._resolved_versions = None
+        # One session, so the tens of sequential calls a `gate` run makes reuse
+        # a connection instead of repeating the TCP and TLS handshake each time.
+        self._session = requests.Session()
         self._api_call_stats = {
             'total_calls': 0,
             'total_time': 0.0,
@@ -198,7 +201,7 @@ class LynkAPIClient:
         start_time = time.time()
 
         try:
-            response = requests.post(
+            response = self._session.post(
                 self.config.api_url,
                 headers=headers,
                 json=request_data,
@@ -599,7 +602,7 @@ class LynkAPIClient:
             try:
                 with open(sbom_file, 'rb') as sbom:
                     files_map = {'0': sbom}
-                    response = requests.post(
+                    response = self._session.post(
                         self.config.api_url,
                         headers=headers,
                         data=form_data,
@@ -1089,6 +1092,28 @@ class LynkAPIClient:
 
         return True
 
+    def _wait_for_next_poll(self, deadline, poll_interval, describe):
+        """
+        Sleep until the next poll is due, or report that the deadline has passed.
+
+        Holds the deadline arithmetic shared by the polling loops below.
+
+        Args:
+            deadline (float): time.time() timestamp to give up at (None = do not wait)
+            poll_interval (int): Seconds between attempts
+            describe (callable): Given the whole seconds left, returns the line to print
+
+        Returns:
+            bool: True if it waited and the caller should retry, False if out of time
+        """
+        remaining = (deadline - time.time()) if deadline else 0
+        if remaining <= 0:
+            return False
+
+        print(describe(int(remaining)))
+        time.sleep(min(poll_interval, remaining))
+        return True
+
     def resolve_version_with_retry(self, prod_name, env_name, ver_name,
                                    deadline=None,
                                    poll_interval=DEFAULT_GATE_POLL_INTERVAL):
@@ -1116,15 +1141,14 @@ class LynkAPIClient:
             if self.resolve_product_env(prod_name, env_name, ver_name):
                 return True
 
-            remaining = (deadline - time.time()) if deadline else 0
-            if remaining <= 0:
+            if not self._wait_for_next_poll(
+                    deadline, poll_interval,
+                    lambda left, n=attempt: f'Version {ver_name!r} not found yet (attempt {n}), '
+                                            f'retrying in {poll_interval}s... [{left}s left]'):
                 return False
 
             # Reset partial resolution state before retrying
             self.config.ver_id = None
-            print(f'Version {ver_name!r} not found yet (attempt {attempt}), '
-                  f'retrying in {poll_interval}s... [{int(remaining)}s left]')
-            time.sleep(min(poll_interval, remaining))
 
     def get_policy_gate(self, sbom_id, fail_on='fail', policy_id=None,
                         policy_name=None):
@@ -1200,14 +1224,12 @@ class LynkAPIClient:
             if status not in (GATE_STATUS_IN_PROGRESS, GATE_STATUS_ERROR):
                 return gate
 
-            remaining = (deadline - time.time()) if deadline else 0
-            if remaining <= 0:
+            if not self._wait_for_next_poll(
+                    deadline, poll_interval,
+                    lambda left, g=gate, st=status: f'Policy scan {st.lower().replace("_", " ")} '
+                                                    f'(run: {g.get("policyRunStatus", "?")}), '
+                                                    f'retrying in {poll_interval}s... [{left}s left]'):
                 return gate
-
-            print(f'Policy scan {status.lower().replace("_", " ")} '
-                  f'(run: {gate.get("policyRunStatus", "?")}), '
-                  f'retrying in {poll_interval}s... [{int(remaining)}s left]')
-            time.sleep(min(poll_interval, remaining))
 
     def print_api_summary(self):
         """Print summary of API calls made during the session."""

--- a/pylynk/api/client.py
+++ b/pylynk/api/client.py
@@ -23,10 +23,11 @@ import requests
 from pylynk.constants import (
     API_TIMEOUT, DEFAULT_ENVIRONMENT,
     STATUS_NOT_STARTED, STATUS_IN_PROGRESS, STATUS_FINISHED,
-    STATUS_COMPLETED, STATUS_UNKNOWN, STATUS_KEYS
+    STATUS_COMPLETED, STATUS_UNKNOWN, STATUS_KEYS,
+    GATE_STATUS_IN_PROGRESS, GATE_STATUS_ERROR
 )
 from pylynk.utils.validators import validate_file_exists, validate_boolean_flag, parse_boolean_flag
-from pylynk.api.queries import PRODUCTS_TOTAL_COUNT, PRODUCTS_LIST, PRODUCTS_LIST_LITE, SBOM_DOWNLOAD, SBOM_DOWNLOAD_NEW, VULNS_LIST, ATTRIBUTIONS_QUERY, ATTRIBUTIONS_WITH_TEXT_QUERY, PRODUCT_BY_NAME, VEX_STATUSES_LIST, VEX_JUSTIFICATIONS_LIST, CDX_RESPONSES_LIST
+from pylynk.api.queries import PRODUCTS_TOTAL_COUNT, PRODUCTS_LIST, PRODUCTS_LIST_LITE, SBOM_DOWNLOAD, SBOM_DOWNLOAD_NEW, VULNS_LIST, ATTRIBUTIONS_QUERY, ATTRIBUTIONS_WITH_TEXT_QUERY, PRODUCT_BY_NAME, VEX_STATUSES_LIST, VEX_JUSTIFICATIONS_LIST, CDX_RESPONSES_LIST, SBOM_POLICY_GATE
 from pylynk.api.mutations import SBOM_UPLOAD, COMPONENT_VEX_UPDATE, COMPONENT_VEX_BULK_UPDATE
 
 
@@ -1087,6 +1088,104 @@ class LynkAPIClient:
             print(f"No version specified, using latest version: {ver_display}")
 
         return True
+
+    def resolve_version_with_retry(self, prod_name, env_name, ver_name,
+                                   deadline, poll_interval=15):
+        """
+        Resolve product/environment/version, retrying until the version appears.
+
+        SBOM upload is fully asynchronous - the version record is created by a
+        background job after the upload request returns - so a gate command run
+        right after upload must wait for the version to exist.
+
+        Args:
+            prod_name (str): Product name
+            env_name (str): Environment name
+            ver_name (str): Version name (required - no latest-version fallback)
+            deadline (float): time.time() timestamp to give up at
+            poll_interval (int): Seconds between attempts
+
+        Returns:
+            bool: True if resolved (config.ver_id is set), False on timeout
+        """
+        attempt = 0
+        while True:
+            attempt += 1
+            if self.resolve_product_env(prod_name, env_name, ver_name):
+                return True
+
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                return False
+
+            # Reset partial resolution state before retrying
+            self.config.ver_id = None
+            print(f'Version {ver_name!r} not found yet (attempt {attempt}), '
+                  f'retrying in {poll_interval}s... [{int(remaining)}s left]')
+            time.sleep(min(poll_interval, remaining))
+
+    def get_policy_gate(self, sbom_id, fail_on='fail'):
+        """
+        Fetch the aggregate policy gate verdict for an SBOM.
+
+        Args:
+            sbom_id (str): SBOM (version) ID
+            fail_on (str): Lowest severity that blocks - 'fail' or 'warn'
+
+        Returns:
+            dict: Gate payload (status, counts, violatingPolicies, ...) or None on error
+        """
+        result = self._make_request(
+            SBOM_POLICY_GATE,
+            variables={'sbomId': sbom_id, 'failOn': fail_on},
+            operation_name='GetSbomPolicyGate'
+        )
+
+        if not result or result.get('errors'):
+            return None
+
+        gate = (result.get('data') or {}).get('sbomPolicyGate')
+        if not gate:
+            print('Error: SBOM not found - check product, environment, and version')
+            return None
+
+        return gate
+
+    def wait_for_policy_gate(self, sbom_id, fail_on='fail', deadline=None,
+                             poll_interval=15):
+        """
+        Poll the policy gate until it reaches a terminal status or the deadline.
+
+        Polls while the gate reports IN_PROGRESS or ERROR. ERROR is usually the
+        transient window where a superseding scan interrupted a running one;
+        if it persists until the deadline the caller treats it as indeterminate.
+
+        Args:
+            sbom_id (str): SBOM (version) ID
+            fail_on (str): Lowest severity that blocks - 'fail' or 'warn'
+            deadline (float): time.time() timestamp to give up at (None = single check)
+            poll_interval (int): Seconds between polls
+
+        Returns:
+            dict: Last gate payload seen (never None unless the query itself fails)
+        """
+        while True:
+            gate = self.get_policy_gate(sbom_id, fail_on)
+            if gate is None:
+                return None
+
+            status = gate.get('status')
+            if status not in (GATE_STATUS_IN_PROGRESS, GATE_STATUS_ERROR):
+                return gate
+
+            remaining = (deadline - time.time()) if deadline else 0
+            if remaining <= 0:
+                return gate
+
+            print(f'Policy scan {status.lower().replace("_", " ")} '
+                  f'(run: {gate.get("policyRunStatus", "?")}), '
+                  f'retrying in {poll_interval}s... [{int(remaining)}s left]')
+            time.sleep(min(poll_interval, remaining))
 
     def print_api_summary(self):
         """Print summary of API calls made during the session."""

--- a/pylynk/api/client.py
+++ b/pylynk/api/client.py
@@ -1124,24 +1124,36 @@ class LynkAPIClient:
                   f'retrying in {poll_interval}s... [{int(remaining)}s left]')
             time.sleep(min(poll_interval, remaining))
 
-    def get_policy_gate(self, sbom_id, fail_on='fail'):
+    def get_policy_gate(self, sbom_id, fail_on='fail', policy_id=None,
+                        policy_name=None):
         """
         Fetch the aggregate policy gate verdict for an SBOM.
 
         Args:
             sbom_id (str): SBOM (version) ID
             fail_on (str): Lowest severity that blocks - 'fail' or 'warn'
+            policy_id (str): Optional active policy ID to gate on
+            policy_name (str): Optional active policy name to gate on
 
         Returns:
             dict: Gate payload (status, counts, violatingPolicies, ...) or None on error
         """
         result = self._make_request(
             SBOM_POLICY_GATE,
-            variables={'sbomId': sbom_id, 'failOn': fail_on},
+            variables={
+                'sbomId': sbom_id,
+                'failOn': fail_on,
+                'policyId': policy_id,
+                'policyName': policy_name,
+            },
             operation_name='GetSbomPolicyGate'
         )
 
-        if not result or result.get('errors'):
+        if not result:
+            return None
+        if result.get('errors'):
+            for error in result['errors']:
+                print(f"Error: {error.get('message', 'GraphQL request failed')}")
             return None
 
         gate = (result.get('data') or {}).get('sbomPolicyGate')
@@ -1152,7 +1164,8 @@ class LynkAPIClient:
         return gate
 
     def wait_for_policy_gate(self, sbom_id, fail_on='fail', deadline=None,
-                             poll_interval=15):
+                             poll_interval=15, policy_id=None,
+                             policy_name=None):
         """
         Poll the policy gate until it reaches a terminal status or the deadline.
 
@@ -1165,12 +1178,19 @@ class LynkAPIClient:
             fail_on (str): Lowest severity that blocks - 'fail' or 'warn'
             deadline (float): time.time() timestamp to give up at (None = single check)
             poll_interval (int): Seconds between polls
+            policy_id (str): Optional active policy ID to gate on
+            policy_name (str): Optional active policy name to gate on
 
         Returns:
             dict: Last gate payload seen (never None unless the query itself fails)
         """
         while True:
-            gate = self.get_policy_gate(sbom_id, fail_on)
+            gate = self.get_policy_gate(
+                sbom_id,
+                fail_on,
+                policy_id=policy_id,
+                policy_name=policy_name,
+            )
             if gate is None:
                 return None
 

--- a/pylynk/api/queries.py
+++ b/pylynk/api/queries.py
@@ -435,8 +435,8 @@ query GetVulnProductDetails($projectId: Uuid!, $sbomId: Uuid!, $first: Int, $aft
 
 # Query to get the aggregate policy gate verdict for an SBOM
 SBOM_POLICY_GATE = """
-query GetSbomPolicyGate($sbomId: Uuid!, $failOn: String) {
-  sbomPolicyGate(sbomId: $sbomId, failOn: $failOn) {
+query GetSbomPolicyGate($sbomId: Uuid!, $failOn: String, $policyId: Uuid, $policyName: String) {
+  sbomPolicyGate(sbomId: $sbomId, failOn: $failOn, policyId: $policyId, policyName: $policyName) {
     status
     policyRunStatus
     evaluatedAt

--- a/pylynk/api/queries.py
+++ b/pylynk/api/queries.py
@@ -435,7 +435,7 @@ query GetVulnProductDetails($projectId: Uuid!, $sbomId: Uuid!, $first: Int, $aft
 
 # Query to get the aggregate policy gate verdict for an SBOM
 SBOM_POLICY_GATE = """
-query GetSbomPolicyGate($sbomId: Uuid!, $failOn: String, $policyId: Uuid, $policyName: String) {
+query GetSbomPolicyGate($sbomId: Uuid!, $failOn: PolicyGateFailOnEnum, $policyId: Uuid, $policyName: String) {
   sbomPolicyGate(sbomId: $sbomId, failOn: $failOn, policyId: $policyId, policyName: $policyName) {
     status
     policyRunStatus

--- a/pylynk/api/queries.py
+++ b/pylynk/api/queries.py
@@ -432,3 +432,28 @@ query GetVulnProductDetails($projectId: Uuid!, $sbomId: Uuid!, $first: Int, $aft
   }
 }
 """
+
+# Query to get the aggregate policy gate verdict for an SBOM
+SBOM_POLICY_GATE = """
+query GetSbomPolicyGate($sbomId: Uuid!, $failOn: String) {
+  sbomPolicyGate(sbomId: $sbomId, failOn: $failOn) {
+    status
+    policyRunStatus
+    evaluatedAt
+    counts {
+      total
+      failed
+      warned
+      passed
+      errored
+      skipped
+    }
+    violatingPolicies {
+      policyId
+      policyName
+      resultType
+      violationsCount
+    }
+  }
+}
+"""

--- a/pylynk/cli/commands/gate.py
+++ b/pylynk/cli/commands/gate.py
@@ -20,20 +20,42 @@ from pylynk.formatters.table_formatter import format_gate_table
 from pylynk.constants import (
     EXIT_SUCCESS, EXIT_ERROR, EXIT_POLICY_FAIL, EXIT_INDETERMINATE,
     GATE_STATUS_PASS, GATE_STATUS_FAIL, GATE_STATUS_ERROR,
-    GATE_STATUS_IN_PROGRESS, GATE_STATUS_NOT_EVALUATED, GATE_STATUS_NO_POLICIES
+    GATE_STATUS_IN_PROGRESS, GATE_STATUS_NOT_EVALUATED, GATE_STATUS_NO_POLICIES,
+    GATE_COLUMNS
 )
+
+# Exit code and closing note for each gate status, in one place so the two
+# cannot drift. Anything unexpected falls through to the fail-closed default.
+GATE_OUTCOMES = {
+    GATE_STATUS_PASS: (EXIT_SUCCESS, None),
+    GATE_STATUS_NO_POLICIES: (
+        EXIT_SUCCESS,
+        'Warning: no active policies are configured for this organization '
+        '- gate passes by default'),
+    GATE_STATUS_FAIL: (EXIT_POLICY_FAIL, None),
+    GATE_STATUS_IN_PROGRESS: (
+        EXIT_INDETERMINATE,
+        'Policy scan is still running - failing closed'),
+    GATE_STATUS_ERROR: (
+        EXIT_INDETERMINATE,
+        'Policy evaluation is incomplete or errored - failing closed'),
+    GATE_STATUS_NOT_EVALUATED: (
+        EXIT_INDETERMINATE,
+        'Policies were not evaluated for this SBOM (is vulnerability scanning '
+        'enabled for the environment?) - failing closed'),
+}
 
 
 def _format_violations(gate):
     """Flatten violating policies into table rows keyed by header name."""
-    rows = []
-    for violation in gate.get('violatingPolicies') or []:
-        rows.append({
-            'POLICY': violation.get('policyName', ''),
-            'SEVERITY': violation.get('resultType', ''),
-            'VIOLATIONS': violation.get('violationsCount', 0),
-        })
-    return rows
+    return [
+        {
+            GATE_COLUMNS['policy']['header']: violation.get('policyName', ''),
+            GATE_COLUMNS['severity']['header']: violation.get('resultType', ''),
+            GATE_COLUMNS['violations']['header']: violation.get('violationsCount', 0),
+        }
+        for violation in gate.get('violatingPolicies') or []
+    ]
 
 
 def _print_summary(gate):
@@ -44,16 +66,6 @@ def _print_summary(gate):
           f"(passed: {counts.get('passed', 0)}, failed: {counts.get('failed', 0)}, "
           f"warned: {counts.get('warned', 0)}, skipped: {counts.get('skipped', 0)}, "
           f"errored: {counts.get('errored', 0)})")
-
-
-def _exit_code_for(status):
-    """Map a gate status to the command exit code (fail closed)."""
-    if status in (GATE_STATUS_PASS, GATE_STATUS_NO_POLICIES):
-        return EXIT_SUCCESS
-    if status == GATE_STATUS_FAIL:
-        return EXIT_POLICY_FAIL
-    # IN_PROGRESS (timed out), ERROR, NOT_EVALUATED or anything unexpected
-    return EXIT_INDETERMINATE
 
 
 def execute(api_client, config):
@@ -74,8 +86,8 @@ def execute(api_client, config):
     if not config.ver_id:
         resolved = api_client.resolve_version_with_retry(
             config.prod, config.env, config.ver,
-            deadline=deadline or time.time(),
-            poll_interval=config.gate_poll_interval,
+            deadline=deadline,
+            poll_interval=config.poll_interval,
         )
         if not resolved:
             print('Could not resolve product, environment, or version')
@@ -87,7 +99,7 @@ def execute(api_client, config):
         config.ver_id,
         fail_on=config.fail_on,
         deadline=deadline,
-        poll_interval=config.gate_poll_interval,
+        poll_interval=config.poll_interval,
         policy_id=config.policy_id,
         policy_name=config.policy_name,
     )
@@ -107,17 +119,9 @@ def execute(api_client, config):
             print()
             format_gate_table(rows)
 
-    # Human-readable outcome notes (stdout, after the data)
-    if status == GATE_STATUS_NO_POLICIES:
-        print('Warning: no active policies are configured for this '
-              'organization - gate passes by default')
-    elif status == GATE_STATUS_IN_PROGRESS:
-        print(f'Timeout: policy scan still running after {config.gate_timeout}s '
-              '- failing closed (exit 4)')
-    elif status == GATE_STATUS_ERROR:
-        print('Policy evaluation is incomplete or errored - failing closed (exit 4)')
-    elif status == GATE_STATUS_NOT_EVALUATED:
-        print('Policies were not evaluated for this SBOM (is vulnerability '
-              'scanning enabled for the environment?) - failing closed (exit 4)')
+    # Human-readable outcome note (stdout, after the data)
+    exit_code, note = GATE_OUTCOMES.get(status, (EXIT_INDETERMINATE, None))
+    if note:
+        print(f'{note} (exit {exit_code})')
 
-    return _exit_code_for(status)
+    return exit_code

--- a/pylynk/cli/commands/gate.py
+++ b/pylynk/cli/commands/gate.py
@@ -1,0 +1,121 @@
+# Copyright 2025 Interlynk.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gate command implementation - CI policy gate with blocking exit codes."""
+
+import time
+from pylynk.formatters.json_formatter import format_json
+from pylynk.formatters.table_formatter import format_gate_table
+from pylynk.constants import (
+    EXIT_SUCCESS, EXIT_ERROR, EXIT_POLICY_FAIL, EXIT_INDETERMINATE,
+    GATE_STATUS_PASS, GATE_STATUS_FAIL, GATE_STATUS_ERROR,
+    GATE_STATUS_IN_PROGRESS, GATE_STATUS_NOT_EVALUATED, GATE_STATUS_NO_POLICIES
+)
+
+
+def _format_violations(gate):
+    """Flatten violating policies into table rows keyed by header name."""
+    rows = []
+    for violation in gate.get('violatingPolicies') or []:
+        rows.append({
+            'POLICY': violation.get('policyName', ''),
+            'SEVERITY': violation.get('resultType', ''),
+            'VIOLATIONS': violation.get('violationsCount', 0),
+        })
+    return rows
+
+
+def _print_summary(gate):
+    """Print the gate verdict summary."""
+    counts = gate.get('counts') or {}
+    print(f"Policy gate: {gate.get('status', 'UNKNOWN')}")
+    print(f"  Policies evaluated: {counts.get('total', 0)} "
+          f"(passed: {counts.get('passed', 0)}, failed: {counts.get('failed', 0)}, "
+          f"warned: {counts.get('warned', 0)}, skipped: {counts.get('skipped', 0)}, "
+          f"errored: {counts.get('errored', 0)})")
+
+
+def _exit_code_for(status):
+    """Map a gate status to the command exit code (fail closed)."""
+    if status in (GATE_STATUS_PASS, GATE_STATUS_NO_POLICIES):
+        return EXIT_SUCCESS
+    if status == GATE_STATUS_FAIL:
+        return EXIT_POLICY_FAIL
+    # IN_PROGRESS (timed out), ERROR, NOT_EVALUATED or anything unexpected
+    return EXIT_INDETERMINATE
+
+
+def execute(api_client, config):
+    """
+    Execute the gate command.
+
+    Args:
+        api_client: Initialized API client
+        config: Configuration object
+
+    Returns:
+        int: Exit code - 0 pass, 1 operational error, 3 policy failure,
+             4 indeterminate (timeout, scan error, or not evaluated)
+    """
+    deadline = time.time() + config.gate_timeout if config.gate_wait else None
+
+    # Resolve names to the SBOM ID unless --verId was given (never clobber it)
+    if not config.ver_id:
+        resolved = api_client.resolve_version_with_retry(
+            config.prod, config.env, config.ver,
+            deadline=deadline or time.time(),
+            poll_interval=config.gate_poll_interval,
+        )
+        if not resolved:
+            print('Could not resolve product, environment, or version')
+            print('If the SBOM was just uploaded, processing may not have '
+                  'started yet - consider a longer --timeout')
+            return EXIT_ERROR
+
+    gate = api_client.wait_for_policy_gate(
+        config.ver_id,
+        fail_on=config.fail_on,
+        deadline=deadline,
+        poll_interval=config.gate_poll_interval,
+    )
+
+    if gate is None:
+        print('Failed to fetch policy gate verdict')
+        return EXIT_ERROR
+
+    status = gate.get('status')
+
+    if config.output_format == 'json':
+        format_json(gate)
+    else:
+        _print_summary(gate)
+        rows = _format_violations(gate)
+        if rows:
+            print()
+            format_gate_table(rows)
+
+    # Human-readable outcome notes (stdout, after the data)
+    if status == GATE_STATUS_NO_POLICIES:
+        print('Warning: no active policies are configured for this '
+              'organization - gate passes by default')
+    elif status == GATE_STATUS_IN_PROGRESS:
+        print(f'Timeout: policy scan still running after {config.gate_timeout}s '
+              '- failing closed (exit 4)')
+    elif status == GATE_STATUS_ERROR:
+        print('Policy evaluation is incomplete or errored - failing closed (exit 4)')
+    elif status == GATE_STATUS_NOT_EVALUATED:
+        print('Policies were not evaluated for this SBOM (is vulnerability '
+              'scanning enabled for the environment?) - failing closed (exit 4)')
+
+    return _exit_code_for(status)

--- a/pylynk/cli/commands/gate.py
+++ b/pylynk/cli/commands/gate.py
@@ -88,6 +88,8 @@ def execute(api_client, config):
         fail_on=config.fail_on,
         deadline=deadline,
         poll_interval=config.gate_poll_interval,
+        policy_id=config.policy_id,
+        policy_name=config.policy_name,
     )
 
     if gate is None:

--- a/pylynk/cli/parser.py
+++ b/pylynk/cli/parser.py
@@ -17,6 +17,8 @@
 import argparse
 import sys
 
+from pylynk.constants import DEFAULT_GATE_TIMEOUT, DEFAULT_GATE_POLL_INTERVAL
+
 
 class CustomArgumentParser(argparse.ArgumentParser):
     """Custom argument parser with improved error messages."""
@@ -402,11 +404,12 @@ the latest-version fallback is disabled because it is racy in CI).
     gate_parser.add_argument("--no-wait", action='store_false', dest='wait',
                              help="Check current state once instead of waiting "
                                   "for the policy scan to finish")
-    gate_parser.add_argument("--timeout", type=int, default=600, metavar='SECS',
-                             help="Total seconds to wait for resolution and "
-                                  "policy scan (default: 600)")
-    gate_parser.add_argument("--poll-interval", type=int, default=15, metavar='SECS',
-                             help="Seconds between polling attempts (default: 15)")
+    gate_parser.add_argument("--timeout", type=int, default=DEFAULT_GATE_TIMEOUT, metavar='SECS',
+                             help="Total seconds to wait for resolution and policy scan "
+                                  f"(default: {DEFAULT_GATE_TIMEOUT})")
+    gate_parser.add_argument("--poll-interval", type=int, default=DEFAULT_GATE_POLL_INTERVAL, metavar='SECS',
+                             help="Seconds between polling attempts "
+                                  f"(default: {DEFAULT_GATE_POLL_INTERVAL})")
     add_output_format_group(gate_parser, include_csv=False)
 
     # Version command

--- a/pylynk/cli/parser.py
+++ b/pylynk/cli/parser.py
@@ -365,6 +365,7 @@ Note: Requires either --verId OR all of --prod, --env, and --ver
 Examples:
   pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0'
   pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0' --timeout 900
+  pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0' --policy-name 'No criticals'
   pylynk gate --verId 'abc-123' --fail-on warn
   pylynk gate --verId 'abc-123' --no-wait --output json
 
@@ -393,6 +394,11 @@ the latest-version fallback is disabled because it is racy in CI).
     add_version_arguments(gate_parser, required=False)
     gate_parser.add_argument("--fail-on", choices=['fail', 'warn'], default='fail',
                              help="Lowest policy severity that blocks (default: fail)")
+    policy_filter_group = gate_parser.add_mutually_exclusive_group()
+    policy_filter_group.add_argument("--policy-name",
+                                     help="Gate on a single active policy by exact name")
+    policy_filter_group.add_argument("--policy-id",
+                                     help="Gate on a single active policy by ID")
     gate_parser.add_argument("--no-wait", action='store_false', dest='wait',
                              help="Check current state once instead of waiting "
                                   "for the policy scan to finish")

--- a/pylynk/cli/parser.py
+++ b/pylynk/cli/parser.py
@@ -63,6 +63,11 @@ def _get_command_examples(command):
   pylynk download --prod 'my-product' --env 'default' --ver 'v1.0.0' --wait-for vuln-scan,automation
   pylynk download --verId 'abc-123' --out-file sbom.json''',
 
+        'gate': '''  pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0'
+  pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0' --timeout 900
+  pylynk gate --verId 'abc-123' --fail-on warn
+  pylynk gate --verId 'abc-123' --no-wait --output json''',
+
         'vulns': '''  pylynk vulns --prod 'my-product'
   pylynk vulns --prod 'my-product' --env 'production'
   pylynk vulns --prod 'my-product' --vuln-details --vex-details
@@ -195,6 +200,7 @@ Examples:
   pylynk vers --prod 'my-product'                 List versions for a product
   pylynk upload --prod 'my-product' --sbom s.json Upload an SBOM
   pylynk download --verId 'abc-123'               Download an SBOM
+  pylynk gate --prod 'p' --env 'default' --ver 'v1.0'  Policy gate for CI (exit 3 on failure)
   pylynk vulns --prod 'my-product'                List vulnerabilities
   pylynk vex update --prod 'p' --ver 'v1.0' --vuln CVE-2024-1234 --status not_affected
   pylynk report --type attribution --prod 'p' --env 'default' --ver 'v1.0'
@@ -353,6 +359,49 @@ Note: Requires either --verId OR all of --prod, --env, and --ver
                                  help="Seconds between polling attempts when using --wait-for (default: 10)")
     download_parser.add_argument("--poll-timeout", type=int, default=300, metavar='SECS',
                                  help="Maximum seconds to wait for processing (default: 300)")
+
+    # Gate command
+    gate_epilog = '''
+Examples:
+  pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0'
+  pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0' --timeout 900
+  pylynk gate --verId 'abc-123' --fail-on warn
+  pylynk gate --verId 'abc-123' --no-wait --output json
+
+Exit codes:
+  0  gate passed (or no active policies configured)
+  1  operational error (auth, network, resolution failure)
+  2  invalid arguments
+  3  policy gate FAILED - blocking violations detected
+  4  indeterminate - scan timed out, errored, or was never evaluated
+
+Note: Requires either --verId OR both --prod and --ver (an explicit version;
+the latest-version fallback is disabled because it is racy in CI).
+'''
+    gate_parser = subparsers.add_parser(
+        "gate",
+        help="Check the policy gate for an SBOM (CI/PR blocking)",
+        description="Check whether an SBOM version passes the organization's "
+                    "policies. Waits for the policy scan to finish and exits "
+                    "non-zero on failure so CI can block the PR.",
+        epilog=gate_epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_create_base_parser()]
+    )
+    add_product_arguments(gate_parser, required=False)
+    add_environment_argument(gate_parser)
+    add_version_arguments(gate_parser, required=False)
+    gate_parser.add_argument("--fail-on", choices=['fail', 'warn'], default='fail',
+                             help="Lowest policy severity that blocks (default: fail)")
+    gate_parser.add_argument("--no-wait", action='store_false', dest='wait',
+                             help="Check current state once instead of waiting "
+                                  "for the policy scan to finish")
+    gate_parser.add_argument("--timeout", type=int, default=600, metavar='SECS',
+                             help="Total seconds to wait for resolution and "
+                                  "policy scan (default: 600)")
+    gate_parser.add_argument("--poll-interval", type=int, default=15, metavar='SECS',
+                             help="Seconds between polling attempts (default: 15)")
+    add_output_format_group(gate_parser, include_csv=False)
 
     # Version command
     version_parser = subparsers.add_parser(

--- a/pylynk/cli/parser.py
+++ b/pylynk/cli/parser.py
@@ -67,6 +67,7 @@ def _get_command_examples(command):
 
         'gate': '''  pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0'
   pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0' --timeout 900
+  pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0' --policy-name 'No criticals'
   pylynk gate --verId 'abc-123' --fail-on warn
   pylynk gate --verId 'abc-123' --no-wait --output json''',
 
@@ -363,18 +364,14 @@ Note: Requires either --verId OR all of --prod, --env, and --ver
                                  help="Maximum seconds to wait for processing (default: 300)")
 
     # Gate command
-    gate_epilog = '''
+    gate_epilog = f'''
 Examples:
-  pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0'
-  pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0' --timeout 900
-  pylynk gate --prod 'my-product' --env 'default' --ver 'v1.0.0' --policy-name 'No criticals'
-  pylynk gate --verId 'abc-123' --fail-on warn
-  pylynk gate --verId 'abc-123' --no-wait --output json
+{_get_command_examples('gate')}
 
 Exit codes:
   0  gate passed (or no active policies configured)
-  1  operational error (auth, network, resolution failure)
-  2  invalid arguments
+  1  operational error (auth, network, resolution, or missing --verId/--prod --ver)
+  2  arguments rejected by the parser
   3  policy gate FAILED - blocking violations detected
   4  indeterminate - scan timed out, errored, or was never evaluated
 

--- a/pylynk/constants.py
+++ b/pylynk/constants.py
@@ -59,6 +59,26 @@ PROCESSING_STAGE_MAP = {
     'policy-scan': 'POLICY_SCAN',
 }
 
+# Exit codes (gate command)
+# 0 = pass, 1 = operational error, 2 = argparse error,
+# 3 = policy gate failed, 4 = indeterminate (timeout/error/not evaluated)
+EXIT_SUCCESS = 0
+EXIT_ERROR = 1
+EXIT_POLICY_FAIL = 3
+EXIT_INDETERMINATE = 4
+
+# Policy gate statuses (from sbomPolicyGate GraphQL query)
+GATE_STATUS_PASS = 'PASS'
+GATE_STATUS_FAIL = 'FAIL'
+GATE_STATUS_ERROR = 'ERROR'
+GATE_STATUS_IN_PROGRESS = 'IN_PROGRESS'
+GATE_STATUS_NOT_EVALUATED = 'NOT_EVALUATED'
+GATE_STATUS_NO_POLICIES = 'NO_POLICIES'
+
+# Gate command defaults
+DEFAULT_GATE_TIMEOUT = 600
+DEFAULT_GATE_POLL_INTERVAL = 15
+
 # SBOM Specification Types
 SBOM_SPEC_SPDX = 'SPDX'
 SBOM_SPEC_CYCLONEDX = 'CycloneDX'
@@ -95,6 +115,15 @@ STATUS_COLUMNS = {
 }
 
 DEFAULT_STATUS_COLUMNS = ['action_key', 'status']
+
+# Gate column definitions for gate command (violating policies table)
+GATE_COLUMNS = {
+    'policy': {'header': 'POLICY'},
+    'severity': {'header': 'SEVERITY'},
+    'violations': {'header': 'VIOLATIONS'},
+}
+
+DEFAULT_GATE_COLUMNS = ['policy', 'severity', 'violations']
 
 # Vulnerability column definitions for vulns command
 # Note: 'part_name' and 'part_version' use special handling based on 'isPart' flag

--- a/pylynk/formatters/table_formatter.py
+++ b/pylynk/formatters/table_formatter.py
@@ -16,7 +16,8 @@
 
 from pylynk.constants import (
     VULN_COLUMNS, PRODUCT_COLUMNS, VERSION_COLUMNS, STATUS_COLUMNS,
-    DEFAULT_PRODUCT_COLUMNS, DEFAULT_VERSION_COLUMNS, DEFAULT_STATUS_COLUMNS
+    DEFAULT_PRODUCT_COLUMNS, DEFAULT_VERSION_COLUMNS, DEFAULT_STATUS_COLUMNS,
+    GATE_COLUMNS, DEFAULT_GATE_COLUMNS
 )
 
 
@@ -104,6 +105,21 @@ def format_status_table(status, columns=None):
 
     columns = columns or DEFAULT_STATUS_COLUMNS
     _format_generic_table(status, columns, STATUS_COLUMNS)
+
+
+def format_gate_table(violations, columns=None):
+    """
+    Format violating policies as a table.
+
+    Args:
+        violations (list): List of pre-formatted violation dictionaries
+        columns (list): Optional list of column names to display
+    """
+    if not violations:
+        return
+
+    columns = columns or DEFAULT_GATE_COLUMNS
+    _format_generic_table(violations, columns, GATE_COLUMNS)
 
 
 def format_vulns_table(vulns, columns):

--- a/pylynk/utils/config.py
+++ b/pylynk/utils/config.py
@@ -16,7 +16,10 @@
 
 import os
 import logging
-from pylynk.constants import DEFAULT_API_URL, ENV_API_URL, ENV_SECURITY_TOKEN, ENV_INCLUDE_CI_METADATA
+from pylynk.constants import (
+    DEFAULT_API_URL, ENV_API_URL, ENV_SECURITY_TOKEN, ENV_INCLUDE_CI_METADATA,
+    DEFAULT_GATE_TIMEOUT
+)
 from pylynk.utils.ci_info import CIInfo
 
 
@@ -77,8 +80,7 @@ class Config:
         # Gate command options
         self.fail_on = getattr(args, 'fail_on', 'fail')
         self.gate_wait = getattr(args, 'wait', True)
-        self.gate_timeout = getattr(args, 'timeout', 600)
-        self.gate_poll_interval = getattr(args, 'poll_interval', 15)
+        self.gate_timeout = getattr(args, 'timeout', DEFAULT_GATE_TIMEOUT)
         self.policy_name = getattr(args, 'policy_name', None)
         self.policy_id = getattr(args, 'policy_id', None)
 

--- a/pylynk/utils/config.py
+++ b/pylynk/utils/config.py
@@ -79,6 +79,8 @@ class Config:
         self.gate_wait = getattr(args, 'wait', True)
         self.gate_timeout = getattr(args, 'timeout', 600)
         self.gate_poll_interval = getattr(args, 'poll_interval', 15)
+        self.policy_name = getattr(args, 'policy_name', None)
+        self.policy_id = getattr(args, 'policy_id', None)
 
         # Report command options
         self.report_type = getattr(args, 'report_type', None)

--- a/pylynk/utils/config.py
+++ b/pylynk/utils/config.py
@@ -74,6 +74,12 @@ class Config:
         # Upload options
         self.retries = getattr(args, 'retries', 3)
 
+        # Gate command options
+        self.fail_on = getattr(args, 'fail_on', 'fail')
+        self.gate_wait = getattr(args, 'wait', True)
+        self.gate_timeout = getattr(args, 'timeout', 600)
+        self.gate_poll_interval = getattr(args, 'poll_interval', 15)
+
         # Report command options
         self.report_type = getattr(args, 'report_type', None)
         self.include_license_text = getattr(args, 'include_license_text', False)


### PR DESCRIPTION
## Summary

Customer ask: block PRs in CI when org policies fail for an uploaded SBOM. This adds `pylynk gate`, the CLI half of the feature backed by interlynk-io/lynk-api#3817.

```yaml
- run: python3 pylynk.py upload --prod "my-app" --env "default" --sbom sbom.json
- run: python3 pylynk.py gate --prod "my-app" --env "default" --ver "v1.2.3" --timeout 600
```

- **Waits by default**: retries name resolution until async upload creates the version, then polls `sbomPolicyGate` until the policy scan finishes. Both phases share one `--timeout` budget; `--no-wait` checks once.
- **Exit codes**: `0` pass/no active policies, `1` operational error, `2` usage, `3` policy failure, `4` indeterminate. Incomplete scans fail closed.
- **Policy controls**: `--fail-on warn` makes warn policies blocking. `--policy-name` or `--policy-id` gates on one active policy instead of all active policies; non-blocking violations are still listed.
- **CI-safe version selection**: requires explicit `--ver` or `--verId`; latest-version fallback is disabled because parallel CI uploads can race.
- **Docs**: `docs/gate.md`, README quick start, and `docs/ci-cd.md` cover usage, exit codes, GitHub Actions, JSON output, and single-policy examples.

## Test plan

- `uv run python -m compileall pylynk`
- `uv run python pylynk.py gate --help`
- E2E against local API: `uv run python pylynk.py gate --prod fails --env default --ver 4.0.0 --timeout 600 --policy-name Highly_Exploitable_EPSS_Vulnerability` returned `FAIL`, evaluated exactly 1 policy, and listed 1 violation.

Requires interlynk-io/lynk-api#3817.

